### PR TITLE
Assign LHOST and LPORT only when specified

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -66,6 +66,12 @@ volumes:
 ## Environment variables
 These variables are only to be used with the `rpc*` tag.
 
+### `METASPLOIT_LHOST`
+Sets the `LHOST` global datastore option in msfconsole.
+
+### `METASPLOIT_LPORT`
+Sets the `LPORT` global datastore option in msfconsole.
+
 ### `METASPLOIT_RPC_HOST`
 Host to serve the RPC server at. 
 

--- a/docker/msfconsole.rc
+++ b/docker/msfconsole.rc
@@ -1,12 +1,9 @@
 <ruby>
-# Set LHOST
-run_single("setg LPORT #{ENV['LPORT']}") if ENV['LPORT']
-if ENV['LHOST']
-  lhost = ENV['LHOST']
-else
-  lhost = %x(hostname -i)
-end
-run_single("setg LHOST #{lhost}")
+# Set global LHOST
+run_single("setg LHOST #{ENV['METASPLOIT_LHOST']}") if ENV['METASPLOIT_LHOST']
+
+# Set global LPORT
+run_single("setg LPORT #{ENV['METASPLOIT_LPORT']}") if ENV['METASPLOIT_LPORT']
 
 # Update the DB config
 require 'erb'

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,13 +48,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2024.2.2"
+version = "2024.6.2"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
-    {file = "certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"},
+    {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
+    {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
 ]
 
 [[package]]
@@ -340,13 +340,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.0"
+version = "4.12.1"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.12.0-py3-none-any.whl", hash = "sha256:b349c66bea9016ac22978d800cfff206d5f9816951f12a7d0ec5578b0a819594"},
-    {file = "typing_extensions-4.12.0.tar.gz", hash = "sha256:8cbcdc8606ebcb0d95453ad7dc5065e6237b6aa230a31e81d0f440c30fed5fd8"},
+    {file = "typing_extensions-4.12.1-py3-none-any.whl", hash = "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"},
+    {file = "typing_extensions-4.12.1.tar.gz", hash = "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snek-sploit"
-version = "0.7.1"
+version = "0.8.0"
 description = "Python RPC client for Metasploit Framework"
 authors = [
     "Jiří Rája <jiri.raja@gmail.com>"


### PR DESCRIPTION
- LHOST and LPORT options are globally set only if the user specifies them
- LHOST and LPORT can now be specified using environment variables
- Bumped version
- Updated dependencies