### PR TITLE
Updated output gathering for consoles and sessions

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,4 @@
+services:
+  metasploit:
+    image: metasploit-framework-rpc
+    build: .

--- a/snek_sploit/lib/rpc/consoles.py
+++ b/snek_sploit/lib/rpc/consoles.py
@@ -223,6 +223,9 @@ class Console:
     def tabs(self, line: str) -> List[str]:
         return self._rpc.tabs(self.id, line)
 
+    # TODO: end_check -> success_flags (change to list)
+    # TODO: success_flag_hard_stop
+    # TODO: do the same in sessions
     def gather_output(
         self, timeout: float = None, reading_delay: float = 1, end_check: str = "", end_check_hard_stop: bool = False
     ) -> str:

--- a/snek_sploit/lib/rpc/consoles.py
+++ b/snek_sploit/lib/rpc/consoles.py
@@ -1,7 +1,7 @@
 import random
 import string
 from dataclasses import dataclass, asdict
-from typing import List
+from typing import List, Optional, Union
 import time
 
 from snek_sploit.lib.context import ContextBase, Context
@@ -223,30 +223,34 @@ class Console:
     def tabs(self, line: str) -> List[str]:
         return self._rpc.tabs(self.id, line)
 
-    # TODO: end_check -> success_flags (change to list)
-    # TODO: success_flag_hard_stop
-    # TODO: do the same in sessions
     def gather_output(
-        self, timeout: float = None, reading_delay: float = 1, end_check: str = "", end_check_hard_stop: bool = False
+        self,
+        timeout: float = None,
+        reading_delay: float = 1,
+        success_flags: Optional[Union[List[str], str]] = None,
+        success_flag_hard_stop: bool = False,
     ) -> str:
         """
         Gather output from the console.
         :param timeout: The maximum time to wait for the output
         :param reading_delay: Delay between the readings
-        :param end_check: String that is checked regularly to check whether the execution has finished
-        :param end_check_hard_stop: Whether to exit once the `end_check` is found
+        :param success_flags: Flags to indicate the gathered output is enough (one flag == stop gathering)
+        :param success_flag_hard_stop: Whether to exit once a success_flag is found
         :return: Gathered output
         """
-        if timeout is not None:
+        if isinstance(success_flags, str):
+            success_flags = [success_flags]
+
+        if timeout:
             timeout = time.time() + timeout
 
         output = ""
         end_is_nigh = False
-        while (console := self.read()).busy or console.data or not output or (end_check and not end_is_nigh):
+        while (console := self.read()).busy or console.data or not output or (success_flags and not end_is_nigh):
             output += console.data
 
-            if end_check and end_check in console.data:
-                if end_check_hard_stop:
+            if success_flags and any(flag in console.data for flag in success_flags):
+                if success_flag_hard_stop:
                     break
                 end_is_nigh = True  # In case the console is still busy, continue to gather the data
 
@@ -269,9 +273,9 @@ class Console:
         command: str,
         timeout: float = None,
         reading_delay: float = 1,
-        end_check: str = "",
-        generate_end_check: bool = True,
-        end_check_hard_stop: bool = False,
+        success_flags: Optional[Union[List[str], str]] = None,
+        generate_success_flag: bool = True,
+        success_flag_hard_stop: bool = False,
     ) -> str:
         """
         Execute a command or a set of commands (separated with `\n`) and gather it's output.
@@ -279,19 +283,19 @@ class Console:
         :param command: Command that will be executed in the console.
         :param timeout: The maximum time to wait for the output
         :param reading_delay: Delay between the readings
-        :param end_check: String that is checked regularly to check whether the execution has finished
-        :param generate_end_check: If `end_check` is empty, generate a custom one and add it to the command
-        :param end_check_hard_stop: Whether to exit once the `end_check` is found and discard the rest of the output
+        :param generate_success_flag: If `success_flags` is undefined, generate a custom one and add it to the command
+        :param success_flags: Flags to indicate the gathered output is enough (one flag == stop gathering)
+        :param success_flag_hard_stop: Whether to exit once a success_flag is found
         :return: Execution output
         """
-        if not end_check and generate_end_check:
-            end_check = "".join(random.choices(string.ascii_letters + string.digits, k=20))
-            command += f"\necho '{end_check}'"
+        if not success_flags and generate_success_flag:
+            success_flags = "".join(random.choices(string.ascii_letters + string.digits, k=20))
+            command += f"\necho '{success_flags}'"
 
         self.clear_buffer()
         self.write(command)
 
-        return self.gather_output(timeout, reading_delay, end_check, end_check_hard_stop)
+        return self.gather_output(timeout, reading_delay, success_flags, success_flag_hard_stop)
 
 
 class Consoles(ContextBase):

--- a/snek_sploit/lib/rpc/sessions.py
+++ b/snek_sploit/lib/rpc/sessions.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from typing import List, Dict, Union
 from dataclasses import dataclass, asdict
@@ -439,62 +440,26 @@ class Session(ABC):
         pass
 
     @abstractmethod
-    def execute(
-        self,
-        command: str,
-        minimal_execution_time: float,
-        timeout: float,
-        success_flags: List[str],
-        reading_delay: float,
-    ) -> str:
+    def execute(self, command: str, timeout: float, reading_delay: float) -> str:
         pass
 
     @abstractmethod
-    def execute_in_shell(
-        self,
-        executable: str,
-        arguments: List[str],
-        minimal_execution_time: float,
-        timeout: float,
-        success_flags: List[str],
-        reading_delay: float,
-    ) -> str:
+    def execute_in_shell(self, executable: str, arguments: List[str], timeout: float, reading_delay: float) -> str:
         pass
 
-    def gather_output(
-        self,
-        minimal_execution_time: float = 3,
-        timeout: float = None,
-        success_flags: List[str] = None,
-        reading_delay: float = 1,
-    ) -> str:
+    def gather_output(self, timeout: float = None, reading_delay: float = 1) -> str:
         """
         Gather output from the session.
-        :param minimal_execution_time: The minimum amount of seconds to wait before exiting in case no output is read
         :param timeout: The maximum time to wait for the output
-        :param success_flags: Flags to indicate the gathered output is enough (one flag == stop gathering)
         :param reading_delay: Delay between the readings
         :return: Gathered output
         """
-        timestamp = time.time()
         if timeout:
-            timeout = timestamp + max(timeout, minimal_execution_time)
-        minimal_execution_time = timestamp + minimal_execution_time
+            timeout = time.time() + timeout
 
         output = ""
-        end_is_nigh = False
-        while (data := self.read()) or (time.time() < minimal_execution_time) or not output:
+        while (data := self.read()) or not output:  # All the data is returned at once
             output += data
-
-            # if end_check and end_check in console.data:
-            #     if end_check_hard_stop:
-            #         break
-            #     end_is_nigh = True  # In case the console is still busy, continue to gather the data
-
-            # TODO: switch to regex?
-            # TODO: make sure at least the last 200 characters are tested, since the data can be split randomly?
-            if success_flags and any(flag in data for flag in success_flags):
-                break
 
             if timeout and time.time() >= timeout:
                 break
@@ -522,31 +487,18 @@ class SessionShell(Session):
     def upgrade_to_meterpreter(self, local_host: str, local_port: int) -> bool:
         return self._rpc.shell_upgrade(self.id, local_host, local_port)
 
-    def execute(
-        self,
-        command: str,
-        minimal_execution_time: float = 3,
-        timeout: float = None,
-        success_flags: List[str] = None,
-        reading_delay: float = 1,
-    ) -> str:
+    def execute(self, command: str, timeout: float = None, reading_delay: float = 1) -> str:
         self.clear_buffer()
         self.write(command)
 
-        return self.gather_output(minimal_execution_time, timeout, success_flags, reading_delay)
+        return self.gather_output(timeout, reading_delay)
 
     def execute_in_shell(
-        self,
-        executable: str,
-        arguments: List[str],
-        minimal_execution_time: float = 3,
-        timeout: float = None,
-        success_flags: List[str] = None,
-        reading_delay: float = 1,
+        self, executable: str, arguments: List[str], timeout: float = None, reading_delay: float = 1
     ) -> str:
         command = " ".join([executable, *arguments])
 
-        return self.execute(command, minimal_execution_time, timeout, success_flags, reading_delay)
+        return self.execute(command, timeout, reading_delay)
 
 
 class SessionMeterpreter(Session):
@@ -575,33 +527,32 @@ class SessionMeterpreter(Session):
     def change_transport(self, options: MeterpreterSessionTransportOptions) -> bool:
         return self._rpc.meterpreter_transport_change(self.id, options)
 
-    def execute(
-        self,
-        command: str,
-        minimal_execution_time: float = 3,
-        timeout: float = None,
-        success_flags: List[str] = None,
-        reading_delay: float = 1,
-    ) -> str:
+    def execute(self, command: str, timeout: float = None, reading_delay: float = 1) -> str:
         self.clear_buffer()
         self.write(command)
 
-        return self.gather_output(minimal_execution_time, timeout, success_flags, reading_delay)
+        return self.gather_output(timeout, reading_delay)
 
     def execute_in_shell(
         self,
         executable: str,
         arguments: List[str],
-        minimal_execution_time: float = 3,
         timeout: float = None,
-        success_flags: List[str] = None,
         reading_delay: float = 1,
     ) -> str:
-        # TODO: Remove the process ID from the output? eg. add postprocessing?
+        # TODO: Remove the process ID from the output? eg. add postprocessing? (will be in a separate method/wrapper)
         self.clear_buffer()
         self.run_single(f"execute -f {executable} -c -i -a {' '.join(arguments)}")
 
-        return self.gather_output(minimal_execution_time, timeout, success_flags, reading_delay)
+        return self.gather_output(timeout, reading_delay)
+
+    def gather_output(self, timeout: float = None, reading_delay: float = 1) -> str:
+        output = super().gather_output(timeout, reading_delay)
+        # This is primarily a hotfix for executing in a shell since it returns some info at the beginning
+        if not re.sub(r"Process \d+ created\.\nChannel \d+ created\.\n", "", output, 1):
+            output += super().gather_output(timeout, reading_delay)
+
+        return output
 
 
 class SessionRing(Session):
@@ -612,31 +563,18 @@ class SessionRing(Session):
     def read(self) -> str:
         return self._rpc.ring_read(self.id)
 
-    def execute(
-        self,
-        command: str,
-        minimal_execution_time: float = 3,
-        timeout: float = None,
-        success_flags: List[str] = None,
-        reading_delay: float = 1,
-    ) -> str:
+    def execute(self, command: str, timeout: float = None, reading_delay: float = 1) -> str:
         self.clear_buffer()
         self.write(command)
 
-        return self.gather_output(minimal_execution_time, timeout, success_flags, reading_delay)
+        return self.gather_output(timeout, reading_delay)
 
     def execute_in_shell(
-        self,
-        executable: str,
-        arguments: List[str],
-        minimal_execution_time: float = 3,
-        timeout: float = None,
-        success_flags: List[str] = None,
-        reading_delay: float = 1,
+        self, executable: str, arguments: List[str], timeout: float = None, reading_delay: float = 1
     ) -> str:
         command = " ".join([executable, *arguments])
 
-        return self.execute(command, minimal_execution_time, timeout, success_flags, reading_delay)
+        return self.execute(command, timeout, reading_delay)
 
 
 class Sessions(ContextBase):

--- a/snek_sploit/lib/rpc/sessions.py
+++ b/snek_sploit/lib/rpc/sessions.py
@@ -476,16 +476,20 @@ class Session(ABC):
         :param reading_delay: Delay between the readings
         :return: Gathered output
         """
-        output = ""
         timestamp = time.time()
-
         if timeout:
             timeout = timestamp + max(timeout, minimal_execution_time)
-
         minimal_execution_time = timestamp + minimal_execution_time
 
-        while (data := self.read()) or (time.time() < minimal_execution_time):
+        output = ""
+        end_is_nigh = False
+        while (data := self.read()) or (time.time() < minimal_execution_time) or not output:
             output += data
+
+            # if end_check and end_check in console.data:
+            #     if end_check_hard_stop:
+            #         break
+            #     end_is_nigh = True  # In case the console is still busy, continue to gather the data
 
             # TODO: switch to regex?
             # TODO: make sure at least the last 200 characters are tested, since the data can be split randomly?


### PR DESCRIPTION
Consoles:

- `end_check` -> `success_flags`
- `generate_end_check` -> `generate_success_flag`
- `end_check_hard_stop` -> `success_flag_hard_stop`
- `success_flags` can be a list, a str, or None

Sessions:

- removed `success_flags` and `minimal_execution_time`
- Updated the `gather_output` method to wait until an output is returned
- Added custom gather_output for Meterpreter sessions to make sure the output is gathered even if a channel/process is created

Development:

- Added a Compose file for testing changes during the development
